### PR TITLE
[Feat] Level6,7 요구사항 구현 (시리즈 버튼 기능 및 더보기/접기 상태 저장 기능)

### DIFF
--- a/HarryPotterLibrary/Controller/BookDetailViewController.swift
+++ b/HarryPotterLibrary/Controller/BookDetailViewController.swift
@@ -19,7 +19,7 @@ final class BookDetailViewController: UIViewController {
         view.addSubview(bookDetailView)
         
         setupBookDetailViewLayout()
-        loadBooks()
+        loadBooks(bookIndex: 0) // 처음 켜면 1번 책으로
     }
     
     // MARK: - BookDetailView 제약 조건
@@ -30,45 +30,35 @@ final class BookDetailViewController: UIViewController {
     }
     
     // MARK: - 데이터 로딩
-    private func loadBooks() {
+    private func loadBooks(bookIndex: Int) {
         bookLeader.loadBooks { [weak self] result in
             // self가 살아있는지 확인하고, 살아있을 때만 코드 실행하는 안전장치
             guard let self = self else { return }
             
             switch result {
             case .success(let books):
-                // 첫 번째 책 제목 표시
-                let index = 0
-                let book = books[0]
-                let chapters = book.chapters
-                bookDetailView.bookTitleView.configure(with: book)
-                bookDetailView.bookInfoView.configure(with: book, index: index)
-                bookDetailView.bookDedicationView.configure(with: book)
-                bookDetailView.bookSummaryView.configure(with: book)
-                bookDetailView.bookChaptersView.configure(with: chapters)
+                let book = books[bookIndex] // 0번째 책
+                configureBookDetail(with: book, index: bookIndex)
             case .failure(let error):
-                // 메인 스레드에서 실행
-                DispatchQueue.main.async {
+                DispatchQueue.main.async { // 메인 스레드에서 실행
                     self.showErrorAlert(message: error.localizedDescription)
                 }
             }
         }
     }
-}
-
-// MARK: - #Preview 사용
-import SwiftUI
-
-struct BookDetailViewControllerPreview: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> BookDetailViewController {
-        return BookDetailViewController()
+    
+    // configure
+    private func configureBookDetail(with book: Book, index: Int) {
+        bookDetailView.bookTitleView.configure(with: book) // Title
+        bookDetailView.bookInfoView.configure(with: book, index: index) // Info
+        bookDetailView.bookDedicationView.configure(with: book) // Dedication
+        bookDetailView.bookSummaryView.configure(with: book, index: index) // Summary
+        bookDetailView.bookChaptersView.configure(with: book) // Chapters
     }
-
-    func updateUIViewController(_ uiViewController: BookDetailViewController, context: Context) {
-        // 업데이트 로직은 필요하지 않음
+    
+    // seriesButton 눌림 액션
+    @objc func seriesButtonTapped(_ button: UIButton) {
+        let selectedIndex = button.tag
+        loadBooks(bookIndex: selectedIndex)
     }
-}
-
-#Preview {
-    BookDetailViewControllerPreview()
 }

--- a/HarryPotterLibrary/Model/BookLeader.swift
+++ b/HarryPotterLibrary/Model/BookLeader.swift
@@ -9,9 +9,18 @@ import Foundation
 
 final class BookLeader {
     
-    private enum DataError: Error {
+    enum DataError: Error, LocalizedError { // LocalizedError 프로토콜: 에러 메시지 직접 지정 가능
         case fileNotFound
         case parsingFailed
+        
+        var errorDescription: String? {
+            switch self {
+            case .fileNotFound:
+                return "데이터 파일을 찾을 수 없습니다."
+            case .parsingFailed:
+                return "데이터를 불러오는데 실패하였습니다."
+            }
+        }
     }
     
     // Success 자리에 [Book]이 들어감 -> 성공하면 책 배열을 반환

--- a/HarryPotterLibrary/View/BookChaptersView.swift
+++ b/HarryPotterLibrary/View/BookChaptersView.swift
@@ -67,6 +67,7 @@ class BookChaptersView: UIView {
         chaptersTitleLabel.textColor = .black
     }
     
+    // 목차 레이블
     private func setupChapterLabelLayout(title: String) -> UILabel {
         let label = UILabel()
         label.text = title

--- a/HarryPotterLibrary/View/BookChaptersView.swift
+++ b/HarryPotterLibrary/View/BookChaptersView.swift
@@ -34,9 +34,10 @@ class BookChaptersView: UIView {
         setupChaptersTitleLabelLayout()
     }
     
-    /// 전달받은 Chapter 배열을 UILabel로 생성해 스택뷰에 추가하는 메서드
-    /// - Parameter chapters: 표시할 Chapter 배열
-    func configure(with chapters: [Chapter]) {
+    /// 전달받은 Book 인스턴스를 기반으로 챕터 목록을 UILabel로 생성하여 스택뷰에 추가하는 메서드
+    /// - Parameter book: 챕터 정보가 포함된 Book 인스턴스
+    func configure(with book: Book) {
+        let chapters = book.chapters
         // configure가 여러번 호출 될 경우, 중복을 막기 위해 제거하는 코드
         chaptersStackView.arrangedSubviews
             .dropFirst() // 첫 번째는 제목 라벨(chaptersLabel)이니까 냅둠

--- a/HarryPotterLibrary/View/BookDedicationView.swift
+++ b/HarryPotterLibrary/View/BookDedicationView.swift
@@ -10,7 +10,6 @@ import SnapKit
 
 final class BookDedicationView: UIView {
     private let dedicationStackView = UIStackView()
-    
     private let dedicationTitleLabel = UILabel()
     private let dedicationContentLabel = UILabel()
     

--- a/HarryPotterLibrary/View/BookDedicationView.swift
+++ b/HarryPotterLibrary/View/BookDedicationView.swift
@@ -40,8 +40,8 @@ final class BookDedicationView: UIView {
         setupDedicationContentLabelLayout()
     }
     
-    /// Book의 dedication 속성을 dedicationContentLabel에 설정하는 메서드
-    /// - Parameter book: 헌정사 정보를 포함한 Book 인스턴스
+    /// 전달받은 Book 인스턴스를 기반으로 헌정사 내용을 설정하는 메서드
+    /// - Parameter book: 헌정사 정보가 포함된 Book 인스턴스
     func configure(with book: Book) {
         dedicationContentLabel.text = book.dedication
     }

--- a/HarryPotterLibrary/View/BookInfoView.swift
+++ b/HarryPotterLibrary/View/BookInfoView.swift
@@ -55,10 +55,10 @@ final class BookInfoView: UIView {
          setupPageCountLabelLayout()
     }
     
-    /// Book 모델 데이터를 받아서 BookInfoView 내부 라벨과 이미지 뷰에 설정하는 메서드
+    /// 전달받은 Book 인스턴스를 기반으로 책 정보의 라벨과 이미지를 설정하는 메서드
     /// - Parameters:
-    ///   - book: 표시할 책 정보(Book 타입)
-    ///   - index: 시리즈 번호(0부터 시작)로, 이미지 에셋 이름 매칭에 사용됨 (예: harrypotter1 ~ harrypotter7)
+    ///   - book: 책 정보가 포함된 Book 인스턴스
+    ///   - index: 시리즈 번호(0부터 시작)로, 이미지 에셋 이름 매칭에 사용 (예: harrypotter1 ~ harrypotter7)
     func configure(with book: Book, index: Int) {
         infoTitleLabel.text = book.title
         authorContentLabel.text = book.author

--- a/HarryPotterLibrary/View/BookSectionTitle.swift
+++ b/HarryPotterLibrary/View/BookSectionTitle.swift
@@ -10,4 +10,3 @@ enum BookSectionTitle {
     static let summary = "Summary"
     static let chapters = "Chapters"
 }
-

--- a/HarryPotterLibrary/View/BookSummaryView.swift
+++ b/HarryPotterLibrary/View/BookSummaryView.swift
@@ -21,6 +21,7 @@ final class BookSummaryView: UIView {
     private var fullSummaryContentText: String = ""
     private var truncatedSummaryContentText: String = ""
     
+    private var bookIndex = 0
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -52,11 +53,13 @@ final class BookSummaryView: UIView {
         setupSummarytoggleButtonLayout()
     }
     
-    /// 주어진 Book 인스턴스의 summary 값을 기반으로 요약 내용을 표시하고,
-    /// 길이에 따라 더보기 버튼의 표시 여부 및 라벨 상태를 설정하는 메서드
-    /// - Parameter book: 요약 정보를 포함한 Book 인스턴스
-    func configure(with book: Book) {
-        isContentExpanded = UserDefaults.standard.bool(forKey: "summaryExpanded")
+    /// 전달받은 Book 인스턴스를 기반으로 요약 내용을 표시하고, 길이에 따라 "더 보기" 버튼 상태를 설정하는 메서드
+    /// - Parameters:
+    ///    - book: 요약 정보가 포함된 Book 인스턴스
+    ///    - index: 시리즈 번호(0부터 시작)로, 책 권수별 요약 쳘침 상태 저장/복원에 사용
+    func configure(with book: Book, index: Int) {
+        bookIndex = index // 아래 UserDefatuls에서 쓸 index 저장
+        isContentExpanded = UserDefaults.standard.bool(forKey: "summaryExpanded\(index)") // 권수별로 true인지 false인지 가져옴
         
         let summary = book.summary
         fullSummaryContentText = summary // 요약 내용 전체
@@ -117,7 +120,7 @@ final class BookSummaryView: UIView {
     @objc private func toggleButtonTapped() {
         isContentExpanded.toggle() // 상태 토글: false -> true, true -> false 전화
         updateSummaryUI()
-        UserDefaults.standard.set(isContentExpanded, forKey: "summaryExpanded")
+        UserDefaults.standard.set(isContentExpanded, forKey: "summaryExpanded\(bookIndex)")
     }
     
     // 더 보기 버튼 타이틀 모음

--- a/HarryPotterLibrary/View/BookSummaryView.swift
+++ b/HarryPotterLibrary/View/BookSummaryView.swift
@@ -59,7 +59,12 @@ final class BookSummaryView: UIView {
     ///    - index: 시리즈 번호(0부터 시작)로, 책 권수별 요약 쳘침 상태 저장/복원에 사용
     func configure(with book: Book, index: Int) {
         bookIndex = index // 아래 UserDefatuls에서 쓸 index 저장
-        isContentExpanded = UserDefaults.standard.bool(forKey: "summaryExpanded\(index)") // 권수별로 true인지 false인지 가져옴
+        
+        do { // UserDefaults load
+            isContentExpanded = try loadContentExpanded(for: index)
+        } catch {
+            print("UserDefatuls에서 불러오기 실패: \(error)")
+        }
         
         let summary = book.summary
         fullSummaryContentText = summary // 요약 내용 전체
@@ -127,5 +132,17 @@ final class BookSummaryView: UIView {
     private enum BookSummaryButtonLabel {
         static let expand = "더 보기"
         static let collapse = "접기"
+    }
+    
+    private func loadContentExpanded(for index: Int) throws -> Bool {
+        let key = "summaryExpanded\(index)"
+        if UserDefaults.standard.object(forKey: key) == nil {
+            throw UserDefaultsError.missingValue
+        }
+        return UserDefaults.standard.bool(forKey: key)
+    }
+    
+    private enum UserDefaultsError: Error {
+        case missingValue
     }
 }

--- a/HarryPotterLibrary/View/BookTitleView.swift
+++ b/HarryPotterLibrary/View/BookTitleView.swift
@@ -22,8 +22,8 @@ final class BookTitleView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    /// Book의 title 속성을 BookTitleView의 titleLabel에 설정하는 메서드
-    /// - Parameter book: 제목 정보를 포함한 Book 인스턴스
+    /// 전달받은 Book 인스턴스를 기반으로 제목 라벨을 설정하는 메서드
+    /// - Parameter book: 제목 정보가 포함된 Book 인스턴스
     func configure(with book: Book) {
         titleLabel.text = book.title
     }

--- a/HarryPotterLibrary/View/BookTopTabView.swift
+++ b/HarryPotterLibrary/View/BookTopTabView.swift
@@ -10,7 +10,9 @@ import SnapKit
 
 final class BookTopTabView: UIView {
 
-    private let seriesButton = UIButton()
+    private let buttonContainerView = UIView()
+    private var seriesButtons: [UIButton] = []
+    private var previousButton: UIButton? // 이전 버튼 기억
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -24,23 +26,57 @@ final class BookTopTabView: UIView {
     
     // MARK: - 뷰 계층 구성
     private func setupUI() {
-        addSubview(seriesButton)
+        addSubview(buttonContainerView)
     }
     
     // MARK: - 제약조건 설정
     private func setupLayout() {
-        seriesButton.setTitle("1", for: .normal) // 우선은 하드코딩
-        seriesButton.titleLabel?.font = .systemFont(ofSize: 16)
-        seriesButton.setTitleColor(.white, for: .normal)
-        seriesButton.backgroundColor = .systemBlue
-        
-        seriesButton.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
+        buttonContainerView.snp.makeConstraints {
+            $0.centerX.equalToSuperview() // 가운데로 정렬
             $0.top.bottom.equalToSuperview()
-            $0.width.height.equalTo(40)
+            // 내부 버튼 크기만큼 leading, trailing 크기 결정
         }
         
-        seriesButton.layer.cornerRadius = 20
-        seriesButton.clipsToBounds = true // 둥글 테두리 벗어나간 부분은 잘려나감
+        setupSeriesButtonLayout()
+    }
+    
+    // MARK: - 버튼 생성 및 제약 추가
+    private func setupSeriesButtonLayout() {
+        // TODO: 여기 구조 나눠주기
+        for index in 0..<7 {
+            let button = UIButton()
+            button.tag = index
+            button.setTitle("\(index + 1)", for: .normal)
+            button.titleLabel?.font = .systemFont(ofSize: 16)
+            button.setTitleColor(.white, for: .normal)
+            button.backgroundColor = .systemBlue
+            button.layer.cornerRadius = 20
+            button.clipsToBounds = true
+            button.addTarget(nil, action: #selector(BookDetailViewController.seriesButtonTapped), for: .touchUpInside)
+            
+            buttonContainerView.addSubview(button)
+            seriesButtons.append(button) // 배열에 넣음
+            
+            button.snp.makeConstraints { make in
+                make.width.height.equalTo(40) // 좌우 고정 값
+                make.top.bottom.equalToSuperview()
+                
+                if let previous = previousButton {
+                    // 이전 버튼이 있으면 offset(12)
+                    make.leading.equalTo(previous.snp.trailing).offset(12)
+                } else {
+                    // 첫 번째 버튼은 왼쪽에 정렬
+                    make.leading.equalToSuperview()
+                }
+            }
+            
+            previousButton = button // 반복되는 제약 조건을 위해서 현재 버튼을 이전 버튼으로 저장
+        }
+        
+        // 반복이 다 끝나면 마지막 버튼이 들어감.
+        // 마지막 버튼에 trailing 제약을 추가해줘서 버튼 그룹에 우측 정렬
+        previousButton?.snp.makeConstraints {
+            $0.trailing.equalToSuperview()
+        }
     }
 }

--- a/HarryPotterLibrary/View/BookTopTabView.swift
+++ b/HarryPotterLibrary/View/BookTopTabView.swift
@@ -9,10 +9,9 @@ import UIKit
 import SnapKit
 
 final class BookTopTabView: UIView {
-
+    
     private let buttonContainerView = UIView()
     private var seriesButtons: [UIButton] = []
-    private var previousButton: UIButton? // 이전 버튼 기억
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -31,42 +30,39 @@ final class BookTopTabView: UIView {
     
     // MARK: - 제약조건 설정
     private func setupLayout() {
+        setupButtonContainerViewLayout()
+        setupSeriesButtonLayout()
+        setupSeriesButtonAction()
+    }
+    
+    // 시리즈 버튼 컨테이너 제약조건
+    private func setupButtonContainerViewLayout() {
         buttonContainerView.snp.makeConstraints {
             $0.centerX.equalToSuperview() // 가운데로 정렬
             $0.top.bottom.equalToSuperview()
             // 내부 버튼 크기만큼 leading, trailing 크기 결정
         }
-        
-        setupSeriesButtonLayout()
     }
     
-    // MARK: - 버튼 생성 및 제약 추가
+    // 시리즈 버튼 제약조건
     private func setupSeriesButtonLayout() {
-        // TODO: 여기 구조 나눠주기
+        var previousButton: UIButton? // 이전 버튼 기억
+        
         for index in 0..<7 {
-            let button = UIButton()
-            button.tag = index
-            button.setTitle("\(index + 1)", for: .normal)
-            button.titleLabel?.font = .systemFont(ofSize: 16)
-            button.setTitleColor(.white, for: .normal)
-            button.backgroundColor = .systemBlue
-            button.layer.cornerRadius = 20
-            button.clipsToBounds = true
-            button.addTarget(nil, action: #selector(BookDetailViewController.seriesButtonTapped), for: .touchUpInside)
-            
+            let button = createSeriesButton(index: index)
             buttonContainerView.addSubview(button)
             seriesButtons.append(button) // 배열에 넣음
             
-            button.snp.makeConstraints { make in
-                make.width.height.equalTo(40) // 좌우 고정 값
-                make.top.bottom.equalToSuperview()
+            button.snp.makeConstraints {
+                $0.width.height.equalTo(40) // 좌우 고정 값
+                $0.top.bottom.equalToSuperview()
                 
                 if let previous = previousButton {
                     // 이전 버튼이 있으면 offset(12)
-                    make.leading.equalTo(previous.snp.trailing).offset(12)
+                    $0.leading.equalTo(previous.snp.trailing).offset(12)
                 } else {
                     // 첫 번째 버튼은 왼쪽에 정렬
-                    make.leading.equalToSuperview()
+                    $0.leading.equalToSuperview()
                 }
             }
             
@@ -77,6 +73,26 @@ final class BookTopTabView: UIView {
         // 마지막 버튼에 trailing 제약을 추가해줘서 버튼 그룹에 우측 정렬
         previousButton?.snp.makeConstraints {
             $0.trailing.equalToSuperview()
+        }
+    }
+    
+    // 버튼 생성
+    private func createSeriesButton(index: Int) -> UIButton {
+        let button = UIButton()
+        button.tag = index
+        button.setTitle("\(index + 1)", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16)
+        button.setTitleColor(.white, for: .normal)
+        button.backgroundColor = .systemBlue
+        button.layer.cornerRadius = 20
+        button.clipsToBounds = true
+        return button
+    }
+
+    // 권수 이동 액션
+    private func setupSeriesButtonAction() {
+        seriesButtons.forEach {
+            $0.addTarget(nil, action: #selector(BookDetailViewController.seriesButtonTapped), for: .touchUpInside)
         }
     }
 }


### PR DESCRIPTION
## 🔥 작업한 내용

### 1. 시리즈 버튼 기능 구현
- 시리즈 버튼 1~7까지 생성
- 각 버튼 클릭 시 해당 책 정보로 UI 업데이트 되도록 구현

### 2. 요약 버튼 상태 저장 및 복원
- UserDefaults를 활용하여 요약(Summary) 뷰의 [더 보기/접기] 버튼 상태를 시리즈 별로 저장
- 앱 재실행 시 저장된 상태를 불러와 해당 시리즈에 맞는 UI 복원

### 예외 처리 구현
- JSON 파싱 실패 및 파일 누락 시 에러 처리
- UserDefaults 값이 없는 경우에도 안전하게 동작하도록 예외 처리

## 📸 스크린샷

<table>
  <tr>
    <td align="center">
      <strong>아이폰 16 Pro Max 시연</strong><br>
      <img src="https://github.com/user-attachments/assets/c0bfa008-0b07-44c2-9fc8-f2fb6620053a" width="300"/>
    </td>
    <td align="center">
      <strong>아이폰 SE2 시연</strong><br>
      <img src="https://github.com/user-attachments/assets/aace96e5-2887-4f9e-bdc1-3e9c2dc01d17" width="300"/>
    </td>
  </tr>
</table>

---

<table>
  <tr>
    <td align="center">
      <strong>JSON 파싱 실패</strong><br>
      <img src="https://github.com/user-attachments/assets/16f7ab5a-9ac4-4b62-b313-41b7ab0edc30" width="300"/>
    </td>
    <td align="center">
      <strong>파일 누락</strong><br>
      <img src="https://github.com/user-attachments/assets/bd9d986e-05c7-42f8-b530-99aacd1cb70c" width="300"/>
    </td>
  </tr>
</table>


## ETC
- iOS 16 이상 다양한 디바이스에서도 콘텐츠가 잘리지 않는걸 확인함
- 콘솔에 Autolayout 관련 경고 메시지 없이 구현 완료